### PR TITLE
Properly handle duplicate commits when pushes are in the equation.

### DIFF
--- a/lib/commit.js
+++ b/lib/commit.js
@@ -14,7 +14,6 @@ function Commit(user, repo, sha) {
 
   this.repoUrl  = 'https://github.com/' + user + '/' + repo;
   this.key      = user + '|' + repo + '|' + sha;
-  this.pathPart = user + '-' + repo + '-' + sha;
 }
 
 Commit.prototype.inspect = function() {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "github": "^0.2.1",
     "request": "^2.40.0",
     "shelljs": "^0.3.0",
-    "sprintf-js": "0.0.7"
+    "sprintf-js": "0.0.7",
+    "tmp": "0.0.24"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Also, use a temporary directory rather than one based on the commit sha
to allow for overlap if it occurs.
